### PR TITLE
caching configuration changes

### DIFF
--- a/deploy/config.libsonnet
+++ b/deploy/config.libsonnet
@@ -5,6 +5,8 @@
 // this should contain most/all of the knobs you need to turn to deploy cortex. 
 // If it is not provided here, you can use mixins on top of the final generated manifests.
 // 
+local default_fifocache_size = 102400;
+
 {
     _config+:: {
         namespace: 'cortex',
@@ -101,6 +103,16 @@
             env: [],
             serviceType: 'ClusterIP',
             resources: {},
+            caching: {
+                chunk_fifocache: {
+                    enable: false,
+                    size: default_fifocache_size,
+                },
+                index_fifocache: {
+                    enable: false,
+                    size: default_fifocache_size,
+                },
+            },
         },
         queryFrontend:: {
             name: 'query-frontend',
@@ -118,6 +130,16 @@
             envKVMixin:: {},
             env: [],
             resources: {},
+            enacaching: {
+                chunk_fifocache: {
+                    enable: false,
+                    size: default_fifocache_size,
+                },
+                index_fifocache: {
+                    enable: false,
+                    size: default_fifocache_size,
+                },
+            },
         },
         tableManager:: {
             name: 'table-manager',

--- a/deploy/lib/ingester.libsonnet
+++ b/deploy/lib/ingester.libsonnet
@@ -15,7 +15,7 @@ local kube = import 'kube-libsonnet/kube.libsonnet';
             '-ingester.normalise-tokens=true',
             '-config-yaml=/etc/cortex/schemaConfig.yaml',
             '-consul.hostname=' + consul_uri,
-            '-memcached.hostname=' + memcached_uri,
+            '-store.index-cache-write.memcached.hostname=' + memcached_uri,
         ];
         
         # Environment Variables


### PR DESCRIPTION
remove memcached chunk caching for ingesters
add fifocache configuration options for rulers and queriers

fifocache can now be configured on rulers and queriers for both
chunk and index caches. The size of the cache is directly configurable
in config.libsonnet

Signed-off-by: Graham Rounds <graham@platform9.com>